### PR TITLE
update several plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <name>Groupon API Parent Pom</name>
   <description>Standardized set of build tool configurations for Groupon API projects</description>
   <url>https://github.com/groupon/api-parent-pom</url>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
 
   <licenses>
     <license>
@@ -86,8 +86,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <!--Dependency versions-->
-    <build-resources.version>1.4.7</build-resources.version>
-    <checkstyle.version>7.8</checkstyle.version>
+    <build-resources.version>1.4.8-SNAPSHOT</build-resources.version>
+    <checkstyle.version>8.14</checkstyle.version>
 
     <!--Coverage Settings-->
     <jacoco.check.line.coverage>0.0</jacoco.check.line.coverage>
@@ -98,22 +98,21 @@
 
     <!--Plugin versions-->
     <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
-    <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
-    <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
-    <maven.dependency.plugin.version>3.0.2</maven.dependency.plugin.version>
+    <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
+    <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
+    <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
     <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
-    <maven.failsafe.plugin.version>2.20.1</maven.failsafe.plugin.version>
-    <maven.findbugs.plugin.version>3.0.5</maven.findbugs.plugin.version>
+    <maven.failsafe.plugin.version>2.22.1</maven.failsafe.plugin.version>
     <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
-    <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>
-    <maven.javadoc.plugin.version>2.10.4</maven.javadoc.plugin.version>
+    <maven.jacoco.plugin.version>0.8.2</maven.jacoco.plugin.version>
+    <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-    <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
+    <maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
     <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
-    <maven.surefire.plugin.version>2.20.1</maven.surefire.plugin.version>
-    <maven.surefire.report.plugin.version>2.18.1</maven.surefire.report.plugin.version>
+    <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>
+    <maven.surefire.report.plugin.version>2.22.1</maven.surefire.report.plugin.version>
     <nexus.staging.plugin.version>1.6.8</nexus.staging.plugin.version>
-    <maven.versions.plugin.version>2.5</maven.versions.plugin.version>
+    <com.github.spotbugs.plugin.version>3.1.8</com.github.spotbugs.plugin.version>
   </properties>
 
   <profiles>
@@ -128,6 +127,18 @@
       </properties>
       <build>
         <plugins>
+          <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
@@ -177,18 +188,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
           </plugin>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>findbugs-maven-plugin</artifactId>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -233,12 +232,12 @@
           <version>${maven.failsafe.plugin.version}</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <version>${maven.findbugs.plugin.version}</version>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>${com.github.spotbugs.plugin.version}</version>
           <executions>
             <execution>
-              <id>findbugs-check</id>
+              <id>spotbugs-check</id>
               <phase>verify</phase>
               <goals>
                 <goal>check</goal>
@@ -412,22 +411,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>versions-maven-plugin</artifactId>
-        <version>${maven.versions.plugin.version}</version>
-        <executions>
-          <execution>
-            <id>default-display-dependency-updates</id>
-            <goals>
-              <goal>display-dependency-updates</goal>
-            </goals>
-            <phase>validate</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <!--Dependency versions-->
-    <build-resources.version>1.4.8-SNAPSHOT</build-resources.version>
+    <build-resources.version>1.5.0</build-resources.version>
     <checkstyle.version>8.14</checkstyle.version>
 
     <!--Coverage Settings-->


### PR DESCRIPTION
- replace findbugs with spot-bugs https://spotbugs.readthedocs.io/en/stable/migration.html
- update checktyle to 8.14
- checkstyle and dependency will run by default instead of ci profile
- removed versions-maven-plugin (deemed too noisy with not much improve)
- updated plugins:
* checkstyle
* compiler
* dependency
* failsafe
* jacoco
* javadoc
* resources 
* surefire
* surefire-report